### PR TITLE
yml: Add extended description for commit message.

### DIFF
--- a/.github/workflows/extract-blobs.yml
+++ b/.github/workflows/extract-blobs.yml
@@ -110,5 +110,6 @@ jobs:
         git init
         git branch -M main-${{ env.DCN }}
         git add .
-        git commit -s -m "${{ env.DCN }}: proprietary: initial vendor tree"
+        git commit -s -m "${{ env.DCN }}: proprietary: initial vendor tree
+        Proprietary were extracted from ${{ env.FDR }}/tree/${{ env.FDB }}"
         gh repo create ${{ env.TR }} --public --description="Vendor tree for ${{ env.DCN }}." --source=. --remote=origin --push


### PR DESCRIPTION
* Since it would be tricky to detect what OTA version were used, considering some OEM use different properties, might as well just add the firmware dump link in it. At least, whoever look can check on which firmware it was extracted.